### PR TITLE
Allow formatting link using placeholder

### DIFF
--- a/mail_extension/cb_options.html
+++ b/mail_extension/cb_options.html
@@ -27,10 +27,10 @@ $EndLicense$
             <label for="new_window">New window</label>
             <br>
 
+            <h4><b>Link-format-string</b></h4>
+            <p>You can optionally wrap the link in a format string using the following placeholders: &#60;link&#62; &#60;subject&#62; &#60;filteredSubject&#62; &#60;tbexe&#62; &#60;dateTime&#62; &#60;date&#62; &#60;time&#62; &#60;localeTime&#62; &#60;sender&#62; &#60;senderName&#62; &#60;senderEmail&#62.</p>
+            <label class=textLabel><input id="format_string" name="format_string" type="text"/></label>
             <h4><b>foobar</b></h4>
-            <p>Optionally add a prefix and suffix before and after the ID on copy.</p>
-            <label class=textLabel>Prefix: <input id="prefix" type="text"/></label>
-            <label class=textLabel>Suffix: <input id="suffix" type="text"/></label>
             <label>Include angle brackets (&lt;&gt;): <input id="copyBrackets" type="checkbox"/></label>
             <br>
             <label>URL Encode the Message ID: <input id="urlEncode" type="checkbox"/></label>

--- a/mail_extension/cb_options.js
+++ b/mail_extension/cb_options.js
@@ -23,33 +23,6 @@ function store_settings() {
     })
 }
 
-function storeSettings() {
-  browser.storage.local.set({
-    copyID: {
-      prefix: prefixInput.value,
-      suffix: suffixInput.value,
-      copyBrackets: copyBrackets.checked,
-      urlEncode: urlEncode.checked,
-      raw: raw.checked
-    }
-  });
-}
-
-/*
-Update the options UI with the settings values retrieved from storage,
-or the default settings if the stored settings are empty.
-*/
-function updateUI(storedSettings) {
-  if (storedSettings.copyID) {
-    prefixInput.value = storedSettings.copyID.prefix;
-    suffixInput.value = storedSettings.copyID.suffix;
-    copyBracketsInput.checked = storedSettings.copyID.copyBrackets;
-    urlEncodeInput.checked = storedSettings.copyID.urlEncode;
-    rawInput.checked = storedSettings.copyID.raw;
-  }
-}
-
-
 /*
 On opening the options page, fetch stored settings and update the UI with them.
 */
@@ -66,9 +39,9 @@ browser.storage.local.get().then((settings) => {
 /*
 On checkbox change, save the currently selected settings.
 */
-copyBracketsInput.addEventListener("change", storeSettings);
-urlEncodeInput.addEventListener("change", storeSettings);
-rawInput.addEventListener("change", storeSettings);
+copyBracketsInput.addEventListener("change", store_settings);
+urlEncodeInput.addEventListener("change", store_settings);
+rawInput.addEventListener("change", store_settings);
 
 document.querySelector("#three_pane")   .addEventListener('change', store_settings)
 document.querySelector("#new_tab")      .addEventListener('change', store_settings)

--- a/mail_extension/cb_options.js
+++ b/mail_extension/cb_options.js
@@ -9,8 +9,6 @@
 // $EndLicense$
 //
 
-const prefixInput = document.querySelector("#prefix");
-const suffixInput = document.querySelector("#suffix");
 const copyBracketsInput = document.querySelector("#copyBrackets");
 const urlEncodeInput = document.querySelector("#urlEncode");
 const rawInput = document.querySelector("#raw");
@@ -19,7 +17,8 @@ function store_settings() {
     console.log(document.querySelector('input[name="open_mode"]:checked').value)
     browser.storage.local.set({
         cb_thunderlink: {
-            open_mode: document.querySelector('input[name="open_mode"]:checked').value
+            open_mode: document.querySelector('input[name="open_mode"]:checked').value,
+            format_string: document.querySelector('input[name="format_string"]').value
         }
     })
 }
@@ -59,6 +58,8 @@ browser.storage.local.get().then((settings) => {
     if (settings.cb_thunderlink) {
         let open_mode = settings.cb_thunderlink.open_mode
         document.getElementById(open_mode).checked = true
+	let format_string = settings.cb_thunderlink.format_string
+	document.querySelector("#format_string").value = format_string
     }
 })
 
@@ -69,14 +70,9 @@ copyBracketsInput.addEventListener("change", storeSettings);
 urlEncodeInput.addEventListener("change", storeSettings);
 rawInput.addEventListener("change", storeSettings);
 
-/*
-On textbox blur, save the currently selected settings.
-*/
-prefixInput.addEventListener("blur", storeSettings);
-suffixInput.addEventListener("blur", storeSettings);
-
-document.querySelector("#three_pane").addEventListener('change', store_settings)
-document.querySelector("#new_tab")   .addEventListener('change', store_settings)
-document.querySelector("#new_window").addEventListener('change', store_settings)
+document.querySelector("#three_pane")   .addEventListener('change', store_settings)
+document.querySelector("#new_tab")      .addEventListener('change', store_settings)
+document.querySelector("#new_window")   .addEventListener('change', store_settings)
+document.querySelector("#format_string").addEventListener('blur', store_settings)
 
 // vim: syntax=javascript ts=4 sw=4 sts=4 sr et columns=120


### PR DESCRIPTION
This implements the corresponding functionality in the thunderlink add-on, basically copying the code from there. I found it simpler (and perhaps more flexible) to have a single format string with a `<link>` placeholder rather than a prefix and suffix.

The format string is optional in the sense that it default to a bare link if the corresponding textbox is left empty in the options page.

At the moment the `<senderName>` and `<senderEmail>` are not working and the corresponding lines from the thunderlink code are commented out in `cb_background.js`. If the `message.author` always has the format `name <email>` then we could get these two placeholders by splitting that string, but I am not sure whether this is the case, do you know?

There is one placeholder that I didn't try to implement: `<tbexe>`. Its value is `path/to/thunderbird.exe -thunderlink ` so I don't think it makes sense anymore.

The thunderlink add-on has allows 7 different format strings. I suppose it wouldn't be too difficult to go from 1 to 7 but I'd rather first see if you're happy with having one.

There is a second commit that removes obsolete code from the option script.