### PR TITLE
Added possibility to use selected text

### DIFF
--- a/mail_extension/cb_options.html
+++ b/mail_extension/cb_options.html
@@ -113,6 +113,10 @@ $EndLicense$
                      (the filtered subject replaces a few characters that frequently cause trouble, 
                      with a focus on org-mode).
                 </li>
+                <li>
+                    $selected_text$ =&gt; Currently selected text
+                     (only available when calling cb_thunderlink by right-clicking in a message tab, <strong>not</strong> from the message list).
+                </li>
             </ul>
             <p>Typical default entries are:</p>
             <ul>


### PR DESCRIPTION
Hi,

in order to reference mails from orgmode, I often found myself using the link via thunderlink, and additionally copying part of the message into a quote block:
```orgmode
#+source: [[thunderlink://messageid=123][mail from foo]]
#+begin_quote
... some content from the mail ...
#+end_quote
```

This CR adds a new placeholder `$selected_text$`, which contains the selected text by the user. A "link" can be configured like this:
```
#+source: [[thunderlink://messageid=$msgid$][$subject_filtered$ $author$]]\n#+begin_quote\n$selected_text$\n#+end_quote\n
```

I have added the `cb_thunderlink` menu additionally to the right click menu in tabs, as only then we can access the current selection.

Some things I stumbled upon while implementing:
- the right click menu is shown in all tabs, which display /any/ content (for example the addon search). I could not figure out how to limit it to tabs which display a mail. IMHO it's not too bad, but maybe you have an idea about this? This is probably relevant: https://developer.thunderbird.net/add-ons/mailextensions/supported-ui-elements#menu-items
- `$selected_text$` is empty if the user uses the `message_list` menu. I thought about hiding any links with the placeholder from that menu, but thats probably a bit confusing, what do you think?